### PR TITLE
Add trailing comma to TypeScript interface definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ All of this data has the same JSON structure:
                feeX: TokenAmount,
                feeY: TokenAmount,
             }
-        ]
-        tokenX: TokenInfo
+        ],
+        tokenX: TokenInfo,
         tokenY: TokenInfo
     }
 }


### PR DESCRIPTION
This PR adds missing trailing commas to the TypeScript interface definition in the documentation. Adding trailing commas is considered **a best practice** in TypeScript for several reasons:

1. **Consistency**: Maintains a consistent code style throughout the codebase.
2. **Cleaner diffs**: When new properties are added in the future, git diffs will only show the new line, not modifications to existing lines.
3. **Error prevention**: Helps prevent errors when converting between different formats (like TS to JSON).
4. **Maintainability**: Makes code easier to refactor and modify in the future.